### PR TITLE
Ruby2 signals

### DIFF
--- a/lib/simpler_workflow/version.rb
+++ b/lib/simpler_workflow/version.rb
@@ -1,3 +1,3 @@
 module SimplerWorkflow
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
Hi,

we are using SimplerWorkflow to build some payment settlement solutions inside our company. Your gem is very "ruby-like": declarative, simple, effective. I'll send another pull request with other contributions that maybe don't fit your style and I totally understand if you don't want to merge them. This one, on the other hand seems like a simple way to make this gem compatible with ruby 2. I found a regular issue when killing the processes via a rake task similar to bin/swf and the rake task currently in the repo. Something similar is mentioned here https://github.com/jstorimer/spin/pull/85 apparently it's all due to the fact that you are using the logger inside the trap and hence that'll (most likely) mean writing to a file, which ruby 2 seems to forbid. With the new changes this errors goes away. Another thing that I changed was to allow a quick QUIT if no task is in process but a polling request already started. I made a very raw variable to check wether it's safe or not to quit right away.

I've been working hard to become better at ruby recently but I'm pretty sure maybe my way isn't the best one, so feel free to let me know if there's something nasty around. Hope this helps. Let me know what you think.

PS: I saw you replied to my question in the issue I opened, I'll test you suggestion asap, I have been working all day on the deployment rake task.

Cheers,

DPT
